### PR TITLE
Break the firmware guide into two parts, add notes about OpenIris

### DIFF
--- a/docs/_pages/Upload_Firmware.md
+++ b/docs/_pages/Upload_Firmware.md
@@ -12,7 +12,9 @@ Uploading your firmware must initially be done over cable. Once you have the tra
 
 ## 1. Connect your tracker to your PC
 
-Connect a programmer board to your esp and then connect the programmer to your pc.
+First, connect your esp32cam to your programmer. In case of the esp32-cam-mb board, it's as simple as sticking it into the socket the way it came in the package and then connecting it your PC with an micro-usb cable.
+
+In case of an FTDI programmer, the steps aren't as easy, so grab [this guide](https://randomnerdtutorials.com/program-upload-code-esp32-cam/) for how to set it up.
 
 ## 2. Build your firmware
 
@@ -22,22 +24,26 @@ Connect a programmer board to your esp and then connect the programmer to your p
 
 ## 3. Upload your firmware
 
-* If you are using the OTA method, first make sure the tracker you wish to flash is turned on.
+- If you are using the OTA method, first make sure the tracker you wish to flash is turned on.
 
-* Once the firmware has been built, press the upload button to upload the firmware.
+- Once the firmware has been built, press the upload button to upload the firmware.
+
+**NOTE** The MB board does the resetting for you, so if you're suing the FTDI programmer, follow the guide linked above (the one from randomnerdtutorials)  
 
   ![img](https://i.imgur.com/lI3PFVC.png)
 
-* If the upload is successful, you should get an output that looks like this:
+- If the upload is successful, you should get an output that looks like this:
 
   ![img](https://i.imgur.com/SDQcCr1.png)
 
 Congratulations! You have now successfully uploaded the firmware to your EyeTrackVR Tracker!
 
 If you have trouble with uploading your firmware over cable check the following:
+
 1. Make sure your USB cable from the tracker is plugged firmly into your PC.
-1. Make sure that your USB cable is a data and charging cable (it is suggested you try other cables or devices with the cable).
-1. Make sure that your drivers are up to date. 
+2. Make sure that your USB cable is a data and charging cable (it is suggested you try other cables or devices with the cable).
+3. Make sure that your drivers are up-to-date.
+4. Some ports might not work, try other ones.
 
 Additionally, this can be caused by software hogging COM ports (**VSCode and Cura can be the cause of this**).
 
@@ -45,18 +51,19 @@ Additionally, this can be caused by software hogging COM ports (**VSCode and Cur
 
 Once you have successfully connected your trackers to your WiFi, you can use OTA to handle all future firmware updates.
 
-1. Retrieve the IP of the tracker you wish to flash. The IP can be found through network monitoring applications, or by veiwing tracker output in a serial monitor.
+1. Retrieve the IP of the tracker you wish to flash. The IP can be found through network monitoring applications, or by viewing tracker output in a serial monitor.
 2. In `platformio.ini` file uncomment the following lines in Visual Studio Code by removing the `;`:
-  ```ini
-  ;upload_protocol = espota
-  ;upload_port = 192.168.1.49
 
-  ```
+```ini
+;upload_protocol = espota
+;upload_port = 192.168.1.49
+
+```
 1. Change the value of upload_port to the IP address retrieved during the first step.
 1. Turn the tracker you wish to flash off and then on again.
 1. Wait around 5 seconds.
 1. Press the upload button to upload the firmware.<br>  
-  ![img](https://i.imgur.com/lI3PFVC.png)
+   ![img](https://i.imgur.com/lI3PFVC.png)
 1. Repeat for as many trackers as you need.
 
 ## Troubleshooting

--- a/docs/_pages/firmware.md
+++ b/docs/_pages/firmware.md
@@ -1,35 +1,39 @@
 ---
 layout: default
-title: Setting Up Firmware
+title: Firmware Guide
 nav_order: 8
 has_children: true
-permalink: /setting-up-firmware-enviroment/
+permalink: /setting-up-firmware/
 ---
 
-# Setting up the environment
+# What is this?
 
-This procedure will show how to prepare your system for uploading the firmware to your tracker.
+Firmware is the second part of the equation to get your trackers going. It lives on the ESP32 chip, and is responsible for streanuthing video data from the tracker.
 
-## 1. Install Visual Studio Code
+# What should I download and where?
 
-Download the [latest Visual Studio Code](https://code.visualstudio.com/download) and install it.
+Current testing has been with `loucass003's` firmware [found here](https://github.com/Futurabeast/futura-face-cam).
+It's tried and working although it's a bit complicated to setup. Download and install this one, for now.
 
-### Download
+We're also working on our own solution called OpenIris, [found here](https://github.com/lorow/OpenIris). So far we have:
 
-![img](https://i.imgur.com/jXPXIFz.gif)
+### Working right now
 
-### Install
+- [x] Basic stream in 60FPS at 248x248px in MJPEG in greyscale
+- [x] A basic HTTP server with API, which allows for better control of the stream and the camera settings
+- [x] Health checks - we know when something goes wrong and we can react to it
+- [x] OTA updates - we can update the firmware on the fly
+- [x] ROI selection for eye area - this feature hasn't been tested all that much yet.
+- [x] MDNS - so that the server itself will detect and communicate with the tracker without you doing anything. No need to configure IPs and stuff, it's automagic
 
-![img](https://i.imgur.com/hAm3Zu0.gif)
+### In development are:
 
-## 2. Install PlatformIO IDE
+- [ ] Persistent storage for storing your settings on the device itself, this will also allow for saving multiple wifi networks!
+- [ ] LED status patterns - so that you know what's going on without plugging the tracker in to the PC
+- [ ] FEC encoding with packet injection for even faster streams!
+- [ ] Better OTA so that updates can be downloaded from github and pushed by the server to the tracker
+- [ ] CI/CD with github actions - so we can more seamlessly update the trackers
 
-Once Visual Studio Code is installed, open it and install [PlatformIO IDE for VSCode](https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide), an extension that will allow you to connect to the tracker, build and upload the firmware.
+# How do download this?
 
-![img](https://i.imgur.com/ebV0IgT.gif)
-
-
-
-
-*Credit goes to the SlimeVR team [adapted from here](https://docs.slimevr.dev/firmware/setup-and-install.html)*
-
+[Follow the steps described here](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)

--- a/docs/_pages/setup_visual_studio.md
+++ b/docs/_pages/setup_visual_studio.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: Setup Visual Studio Code ennvironment
+nav_order: 8
+has_children: true
+permalink: /setting-up-firmware-enviroment/
+parent: Firmware Guide
+---
+
+# Setting up the environment
+
+This procedure will show how to prepare your system for uploading the firmware to your tracker.
+
+## 1. Install Visual Studio Code
+
+Download the [latest Visual Studio Code](https://code.visualstudio.com/download) and install it.
+
+### Download
+
+![img](https://i.imgur.com/jXPXIFz.gif)
+
+### Install
+
+![img](https://i.imgur.com/hAm3Zu0.gif)
+
+## 2. Install PlatformIO IDE
+
+Once Visual Studio Code is installed, open it and install [PlatformIO IDE for VSCode](https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide), an extension that will allow you to connect to the tracker, build and upload the firmware.
+
+![img](https://i.imgur.com/ebV0IgT.gif)
+
+_Credit goes to the SlimeVR team [adapted from here](https://docs.slimevr.dev/firmware/setup-and-install.html)_


### PR DESCRIPTION
# Description

I've broken up the firmware.md file into two separate files: 

- one explaining how to setup VSC
- one explaining how to build and upload the firmware to the esp

I've also added a brief description of what are we using, what is OpenIris, how to get the stuff one's gonna need and I've added an explanation for folks who might get the esp32-cam with an FTDI programmer instead of the MB board (and some typos). 