### PR TITLE
3D Printed Parts for Quest 2 match Valve Index

### DIFF
--- a/docs/_data/3d_printed_parts_yaml/3d_printed_parts.yml
+++ b/docs/_data/3d_printed_parts_yaml/3d_printed_parts.yml
@@ -7,7 +7,7 @@
   hyper_links:
     - url: "https://www.thingiverse.com/thing:5400548"
       desc: "Camera and IR emitter mount by Prohurtz"
-    - url: "https://www.thingiverse.com/thing:5400548"
+    - url: "https://github.com/rrazgriz/IndexEyeTrackVR/tree/main/hardware"
       desc: "Camera mount by Razgriz"
   threed_link_id: 1
 


### PR DESCRIPTION
# Description
The 3D printed parts list in the documentation links to the "Camera and IR emitter mount by Prohurtz" for the "Camera mount by Razgriz". PR changes this link to match the one in the Index segment.

**Related issue (if applicable):** No issue submitted for this change.

## Checklist

- [x] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [x] Only one feature/fix was added per PR and the code change compiles without warnings
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release 

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
