### PR TITLE
Update URL to CLA in PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,6 @@
 - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
 - [ ] The code change is tested and works with EyeTrackVR core ESP32 newest release -->
 
-- [ ] I accept the [CLA](hhttps://github.com/RedHawk989/EyeTrackVR/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).
+- [ ] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 <!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->


### PR DESCRIPTION
# Description
Removes an additional H to allow the hyperlink to populate from markup. Updates the PR URL so clicking the hyperlink will bring the user to that page.

**Related issue (if applicable):** No issue submitted.

## Checklist

- [x] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [x] Only one feature/fix was added per PR and the code change compiles without warnings

    This could have technically been two issues but that could also be considered bloat contributing.
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release

- [x] I accept the [CLA](hhttps://github.com/RedHawk989/EyeTrackVR/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
