### PR TITLE
Fixed requirements.txt

### DIFF
--- a/EyeTrackApp/requirements.txt
+++ b/EyeTrackApp/requirements.txt
@@ -30,4 +30,3 @@ yarg==0.1.9
 zipp==3.6.0
 python-osc==1.8.0
 sympy==1.2
-sympy


### PR DESCRIPTION
# Description
This PR fixes a redefined package in `requirements.txt` that throws an error when installing dependencies because `sympy` is included twice

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).