### PR TITLE
Add missing dependency

### DIFF
--- a/EyeTrackApp/requirements.txt
+++ b/EyeTrackApp/requirements.txt
@@ -30,3 +30,4 @@ yarg==0.1.9
 zipp==3.6.0
 python-osc==1.8.0
 sympy==1.2
+scipy==1.5.4


### PR DESCRIPTION
# Description
This PR fixes `requirements.txt` by adding the missing dependency `scipy`.
(sorry for second PR i didnt notice this the first time around, guess i already had scipy installed already?)

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).
