### PR TITLE
Add executable icon with pyinstaller

### DIFF
--- a/EyeTrackApp/eyetrackapp.spec
+++ b/EyeTrackApp/eyetrackapp.spec
@@ -6,7 +6,7 @@ block_cipher = None
 a = Analysis(['eyetrackapp.py'],
              pathex=[],
              binaries=[],
-             datas=[("Audio/*", "Audio"), ("Images/*", "Images/"), ("pye3dcustom/*", "pye3dcustom/"), ("pye3d/refraction_models/*", "pye3d/refraction_models/")],
+             datas=[("Audio/*", "Audio"), ("Images/*", "Images/"), ("pye3d/refraction_models/*", "pye3d/refraction_models/")],
              hiddenimports=['cv2', 'numpy', 'PySimpleGui'],
              hookspath=[],
              hooksconfig={},
@@ -32,7 +32,8 @@ exe = EXE(pyz,
           disable_windowed_traceback=False,
           target_arch=None,
           codesign_identity=None,
-          entitlements_file=None )
+          entitlements_file=None,
+          icon="Images/logo.ico" )
 coll = COLLECT(exe,
                a.binaries,
                a.zipfiles,


### PR DESCRIPTION
# Description
When compiling with pyinstaller the app icon is "applied" automatically

## Checklist
- [x] Only relevant files were touched
- [x] Code change compiles without warnings
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).
