### PR TITLE
Fix error with black formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,5 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 135
-exclude = "(.git|.env|venv|*.spec)"
+exclude = "(.git|.env|venv)"
 target-version = ["py310","py311"]


### PR DESCRIPTION
# Description
In my first pull request i had black ignore `*.spec` files but apparently black doesnt like wild cards so the PR will remove `*.spec` to allow black to format stuff again

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [x] Code change compiles without warnings
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
