### PR TITLE
Fixes calibration values

### DIFF
--- a/EyeTrackApp/osc_calibrate_filter.py
+++ b/EyeTrackApp/osc_calibrate_filter.py
@@ -12,6 +12,11 @@ class EyeId(IntEnum):
 
 class cal():
     def cal_osc(self, cx, cy):
+        if cx == 0:
+            cx = 1
+        if cy == 0:
+            cy = 1
+
         if self.eye_id == EyeId.RIGHT:
             flipx = self.settings.gui_flip_x_axis_right
         else:
@@ -39,6 +44,7 @@ class cal():
                 self.config.calib_YMAX = cy
             if cy < self.config.calib_YMIN:
                 self.config.calib_YMIN = cy
+            
             self.calibration_frame_counter -= 1
 
         if self.settings.gui_recenter_eyes == True:
@@ -52,53 +58,62 @@ class cal():
         else:
             self.ts = 10
 
-        try:
-            out_x = 0.5
-            out_y = 0.5
-            xl = float(
-                (cx - self.config.calib_XOFF) / (self.config.calib_XMAX - self.config.calib_XOFF)
-            )
-            xr = float(
-                (cx - self.config.calib_XOFF) / (self.config.calib_XMIN - self.config.calib_XOFF)
-            )
-            yu = float(
-                (cy - self.config.calib_YOFF) / (self.config.calib_YMIN - self.config.calib_YOFF)
-            )
-            yd = float(
-                (cy - self.config.calib_YOFF) / (self.config.calib_YMAX - self.config.calib_YOFF)
-            )
+        out_x = 0.5
+        out_y = 0.5
+        
 
-            if self.settings.gui_flip_y_axis:  # check config on flipped values settings and apply accordingly
-                if yd >= 0:
-                    out_y = max(0.0, min(1.0, yd))
-                if yu > 0:
-                    out_y = -abs(max(0.0, min(1.0, yu)))
-            else:
-                if yd >= 0:
-                    out_y = -abs(max(0.0, min(1.0, yd)))
-                if yu > 0:
-                    out_y = max(0.0, min(1.0, yu))
 
-            if flipx:  
-                if xr >= 0:
-                    out_x = -abs(max(0.0, min(1.0, xr)))
-                if xl > 0:
-                    out_x = max(0.0, min(1.0, xl))
-            else:
-                if xr >= 0:
-                    out_x = max(0.0, min(1.0, xr))
-                if xl > 0:
-                    out_x = -abs(max(0.0, min(1.0, xl)))
-        except:
-          #  print("\033[91m[ERROR] Eye Calibration Invalid!\033[0m")
-            self.config.calib_XOFF = 0
-            self.config.calib_YOFF = 0
-            self.config.calib_XMAX = 1
-            self.config.calib_YMAX = 1
-            self.config.calib_XMIN = 1
-            self.config.calib_YMIN = 1
-            out_x = 0.5
-            out_y = 0.5
+        calib_diff_x_MAX = self.config.calib_XMAX - self.config.calib_XOFF
+        if calib_diff_x_MAX == 0:
+            calib_diff_x_MAX = 1
+
+        calib_diff_x_MIN = self.config.calib_XMIN - self.config.calib_XOFF
+        if calib_diff_x_MIN == 0:
+            calib_diff_x_MIN = 1
+
+        calib_diff_y_MAX = self.config.calib_YMAX - self.config.calib_YOFF
+        if calib_diff_y_MAX == 0:
+            calib_diff_y_MAX = 1
+
+        calib_diff_y_MIN = self.config.calib_YMIN - self.config.calib_YOFF
+        if calib_diff_y_MIN == 0:
+            calib_diff_y_MIN = 1
+
+        xl = float(
+            (cx - self.config.calib_XOFF) / calib_diff_x_MAX
+        )
+        xr = float(
+            (cx - self.config.calib_XOFF) / calib_diff_x_MIN
+        )
+        yu = float(
+            (cy - self.config.calib_YOFF) / calib_diff_y_MIN
+        )
+        yd = float(
+            (cy - self.config.calib_YOFF) / calib_diff_y_MAX
+        )
+
+        if self.settings.gui_flip_y_axis:  # check config on flipped values settings and apply accordingly
+            if yd >= 0:
+                out_y = max(0.0, min(1.0, yd))
+            if yu > 0:
+                out_y = -abs(max(0.0, min(1.0, yu)))
+        else:
+            if yd >= 0:
+                out_y = -abs(max(0.0, min(1.0, yd)))
+            if yu > 0:
+                out_y = max(0.0, min(1.0, yu))
+
+        if flipx:  
+            if xr >= 0:
+                out_x = -abs(max(0.0, min(1.0, xr)))
+            if xl > 0:
+                out_x = max(0.0, min(1.0, xl))
+        else:
+            if xr >= 0:
+                out_x = max(0.0, min(1.0, xr))
+            if xl > 0:
+                out_x = -abs(max(0.0, min(1.0, xl)))
+
         try:
             noisy_point = np.array([float(out_x), float(out_y)])  # fliter our values with a One Euro Filter
             point_hat = self.one_euro_filter(noisy_point)


### PR DESCRIPTION
There was a bug that made calibration values all default to 1 if there was a failure of the try/except, fixed the code so it does error checking before running

**Related issue (if applicable):** fixes #<EyeTrackVR issue number goes here>

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [X] Only relevant files were touched
- [X] Code change compiles without warnings
- [X] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [X] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
